### PR TITLE
Allow centered vote results 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ sourcemod-nativevotes-updated (uncletopia)
 
 This fork includes a couple extra features that are not upstreamed:
 
-- Vote results are shown in the center of the screen.
+- Vote results are shown in the center of the screen. Set `nativevotes_progress_centered` to `1`.
 - The ability to have a "curated" map pool. This map pool will be used to pull random maps for voting from instead of the standard, potentially very large, map pool. 
 
 ### Curated Map Pool Setup

--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -85,6 +85,7 @@ ConVar g_Cvar_VoteChat;
 ConVar g_Cvar_VoteConsole;
 ConVar g_Cvar_VoteClientConsole;
 ConVar g_Cvar_VoteDelay;
+ConVar g_Cvar_ProgressCentered;
 
 //----------------------------------------------------------------------------
 // Used to track current vote data
@@ -257,7 +258,8 @@ public void OnPluginStart()
 	g_Cvar_VoteConsole = CreateConVar("nativevotes_progress_console", "0", "Show current vote progress as console messages", FCVAR_NONE, true, 0.0, true, 1.0);
 	g_Cvar_VoteClientConsole = CreateConVar("nativevotes_progress_client_console", "0", "Show current vote progress as console messages to clients", FCVAR_NONE, true, 0.0, true, 1.0);
 	g_Cvar_VoteDelay = CreateConVar("nativevotes_vote_delay", "30", "Sets the recommended time in between public votes", FCVAR_NONE, true, 0.0);
-	
+	g_Cvar_ProgressCentered = CreateConVar("nativevotes_progress_centered", "0", "Show current vote progress centered on the screen", FCVAR_NONE, true, 0.0, true, 1.0);
+
 	Game_InitializeCvars();
 	
 	HookConVarChange(g_Cvar_VoteDelay, OnVoteDelayChange);
@@ -1014,7 +1016,11 @@ void DrawHintProgress()
 	
 	int iTimeRemaining = RoundFloat(timeRemaining);
 
-	PrintCenterTextAll("%t%s", "Vote Count", g_NumVotes, g_TotalClients, iTimeRemaining, g_LeaderList);
+	if (g_Cvar_ProgressCentered.BoolValue) {
+		PrintCenterTextAll("%t%s", "Vote Count", g_NumVotes, g_TotalClients, iTimeRemaining, g_LeaderList);
+	} else {
+		PrintHintTextToAll("%t%s", "Vote Count", g_NumVotes, g_TotalClients, iTimeRemaining, g_LeaderList);
+	}
 }
 
 void BuildVoteLeaders()

--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -1014,7 +1014,7 @@ void DrawHintProgress()
 	
 	int iTimeRemaining = RoundFloat(timeRemaining);
 
-	PrintHintTextToAll("%t%s", "Vote Count", g_NumVotes, g_TotalClients, iTimeRemaining, g_LeaderList);
+	PrintCenterTextAll("%t%s", "Vote Count", g_NumVotes, g_TotalClients, iTimeRemaining, g_LeaderList);
 }
 
 void BuildVoteLeaders()

--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -46,7 +46,7 @@ EngineVersion g_EngineVersion = Engine_Unknown;
 
 #include "nativevotes/data-keyvalues.sp"
 
-#define VERSION 							"1.1.1fix"
+#define VERSION 							"1.1.1fix-ut"
 
 #define LOGTAG "NV"
 


### PR DESCRIPTION
Adds the option to print vote progress in the middle of the screen.

Adds `nativevotes_progress_centered` cvar